### PR TITLE
Update default value for druid.emitter in Configuration.md

### DIFF
--- a/docs/content/Configuration.md
+++ b/docs/content/Configuration.md
@@ -87,7 +87,7 @@ The Druid servers emit various metrics and alerts via something we call an Emitt
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.emitter`|Setting this value to "noop", "logging", or "http" will instantialize one of the emitter modules.|logging|
+|`druid.emitter`|Setting this value to "noop", "logging", or "http" will instantialize one of the emitter modules.|noop|
 
 #### Logging Emitter Module
 


### PR DESCRIPTION
I'm not 100% sure, but looking at the source code (EmitterModule.java) and my experience with a clean druid 0.7 cluster, I believe the default value for `druid.emitter` to be `noop` instead of `logging`, as I was getting no emitted logs at all when not specifying `druid.emitter` in any of the `runtime.properties`, despite having defined a metric monitor.
